### PR TITLE
poll when recording is published and post activity when it succeeds

### DIFF
--- a/lib/api.meetings.js
+++ b/lib/api.meetings.js
@@ -756,24 +756,77 @@ var updateRecording = module.exports.updateRecording = function(req, meetingId, 
                 return callback(err);
             }
 
-            MeetingsAPI.Bbb.updateRecordingsURL(req, recordingId, recording, function(err, info) {
+            MeetingsAPI.Bbb.updateRecordingsURL(req, recordingId, recording, function(err, updateRecording) {
                 if (err) {
                     return callback(err);
                 }
 
                 // get the recordings
-                BBBProxy.executeBBBCall(info.url, function(err, result) {
+                BBBProxy.executeBBBCall(updateRecording.url, function(err, result) {
                     if (err) {
                         return callback(err);
                     }
 
                     if(result.returncode === 'SUCCESS') {
 
-                        meeting.recording = recording;
-                        MeetingsAPI.emit(MeetingsConstants.events.UPDATE_RECORDING, ctx, meeting, function(errs) {
+                        // if recording is being unpublished then just update viewers without polling
+                        if (recording.publish === 'false') {
+                            // Post activity
+                            meeting.recording = recording;
+                            MeetingsAPI.emit(MeetingsConstants.events.UPDATE_RECORDING, ctx, meeting, function(errs) {
 
+                            });
+                            return callback(null, result);
+                        }
+
+                        // Polling to check whether recording has been published
+                        MeetingsAPI.Meetings.getFullMeetingProfile(req.ctx, meetingId, function(err, meetingProfile) {
+
+                            MeetingsAPI.Bbb.getRecordingsURL(req, meetingProfile, function(err, getRecordings) {
+                                var interval_time = 1000;
+                                var retries = 0;
+
+                                var polling_func = function(){
+
+                                    // get the meeting info
+                                    BBBProxy.executeBBBCall(getRecordings.url, function(err, recordingsInfo) {
+
+                                        if(recordingsInfo.returncode === 'SUCCESS') {
+                                            var recordings = recordingsInfo.recordings.recording
+
+                                            // make sure recordings is an array before proceeding
+                                            if (!recordings.length) {
+                                                var temp = recordings;
+                                                recordings = [];
+                                                recordings.push(temp);
+                                            }
+
+                                            for (var r in recordings) {
+                                                if (recordings[r].recordID === recordingId) {
+
+                                                    if (recordings[r].published === 'true') {
+                                                        // Recording updated so post activity
+                                                        meeting.recording = recording;
+                                                        MeetingsAPI.emit(MeetingsConstants.events.UPDATE_RECORDING, ctx, meeting, function(errs) {
+
+                                                        });
+                                                    } else {
+                                                        // retry request
+                                                        if(retries <= 6) {
+                                                            interval_time = interval_time * 2;
+                                                            ++retries;
+                                                            setTimeout(polling_func, interval_time);
+                                                        }
+                                                    }
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    });
+                                }
+                                var poll = setTimeout(polling_func, interval_time);
+                            });
                         });
-
                     }
 
                     return callback(null, result);

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -673,7 +673,7 @@ OAE.tenantRouter.on('get', '/api/recording/:meetingId', function(req, res) {
                     recordingInfo.recordings = recordingInfo.recordings.recording;
 
                     if (!recordingInfo.recordings.length) {
-                        recordings = recordingInfo.recordings;
+                        var recordings = recordingInfo.recordings;
                         recordingInfo.recordings = [];
                         recordingInfo.recordings.push(recordings);
                     }


### PR DESCRIPTION
Publishing an activity
we poll till the recording is published then post an activity that displays links for all viewers

Unpublishing an activity
Skip the polling and post the activity immediately because we are only removing the links